### PR TITLE
#7 Allow illuminate contracts 7.* and 8.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
   ],
   "require": {
     "php": "^7.2",
-    "illuminate/contracts": "^6.0",
+    "illuminate/contracts": "^6.0|^7.0|^8.0",
     "symfony/yaml": "^4.1",
     "justinrainbow/json-schema": "^5.2"
   },


### PR DESCRIPTION
This fixes #7
I already made it support 8.* to be forwards compatible